### PR TITLE
Update database on save instead of editor quit

### DIFF
--- a/attr.go
+++ b/attr.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"text/tabwriter"
 	"time"
+	"gopkg.in/fsnotify.v1"
 )
 
 var out = colorable.NewColorableStdout()
@@ -398,8 +399,53 @@ func (attr attrStruct) incrementFrequency(db *sql.DB) (rowsAffected int64) {
 	return
 }
 
+func (attr attrStruct) updateDb(db *sql.DB, valueText string) (rowsAffected int64) {
+	updateStmt, err := db.Prepare("UPDATE attributes SET value_text = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?")
+	check(err)
+
+	result, err := updateStmt.Exec(valueText, attr.getID())
+	check(err)
+	rowsAffected, err = result.RowsAffected()
+	check(err)
+	return rowsAffected
+}
+
 func (attr attrStruct) edit(db *sql.DB) (rowsAffected int64) {
 	filepath := attr.filepath()
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer watcher.Close()
+	done := make(chan bool)
+	go func() {
+		for {
+			select {
+			case event := <-watcher.Events:
+				if event.Op&fsnotify.Create == fsnotify.Create {
+					if (event.Name == filepath) {
+						valueText := readFile(filepath)
+						rowsAffected = attr.updateDb(db, valueText)
+					}
+				}
+			case err := <-watcher.Errors:
+				log.Println("error:", err)
+			case <-done:
+				// Edit the gofunction
+				return
+			}
+		}
+	}()
+
+	err = watcher.Add("/tmp")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	defer func() {
+		done <- true
+	}()
 
 	if openEditor(filepath) == false {
 		return
@@ -408,13 +454,7 @@ func (attr attrStruct) edit(db *sql.DB) (rowsAffected int64) {
 	valueText := readFile(filepath)
 
 	if valueText != attr.getValue() {
-		updateStmt, err := db.Prepare("UPDATE attributes SET value_text = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?")
-		check(err)
-
-		result, err := updateStmt.Exec(valueText, attr.getID())
-		check(err)
-		rowsAffected, err = result.RowsAffected()
-		check(err)
+		rowsAffected = attr.updateDb(db, valueText)
 	}
 	return
 }


### PR DESCRIPTION
I've been trying this out at work as a note taking tool.  So far I like :+1:

In my workflow, I usually keep the note open in an editor all day and save it periodically. I found that saving the file doesn't update the database since the flow waits until the external editor has closed before reading in the file and updating the db row.  I made a modification to use fsnotify so watch for a change to the temp file and update the rows on that event.

OS tested on: ArchLinux
